### PR TITLE
App login

### DIFF
--- a/pac_app/lib/AuthState.dart
+++ b/pac_app/lib/AuthState.dart
@@ -1,3 +1,12 @@
+
+/**
+ * 권한 체크 AuthState
+ * 
+ * @author 서윤경
+ * @version 1.0
+ * @date 2019.08.16
+ */
+
 enum AuthState{
   admin,
   user,

--- a/pac_app/lib/AuthState.dart
+++ b/pac_app/lib/AuthState.dart
@@ -1,0 +1,5 @@
+enum AuthState{
+  admin,
+  user,
+  noneUser
+}

--- a/pac_app/lib/bloc/AuthBloc.dart
+++ b/pac_app/lib/bloc/AuthBloc.dart
@@ -1,0 +1,19 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:bloc_provider/bloc_provider.dart';
+import 'package:pac_app/AuthState.dart';
+
+import 'package:rxdart/rxdart.dart';
+
+class AuthBloc implements Bloc {
+  final _authentication = BehaviorSubject<AuthState>();
+
+  Stream<AuthState> get authentication => _authentication.stream;
+  Function(AuthState) get setAuthentication => _authentication.sink.add;
+  
+
+  @override
+  dispose() {
+    _authentication.close();
+  }
+}

--- a/pac_app/lib/bloc/AuthBloc.dart
+++ b/pac_app/lib/bloc/AuthBloc.dart
@@ -11,6 +11,9 @@ class AuthBloc implements Bloc {
   Stream<AuthState> get authentication => _authentication.stream;
   Function(AuthState) get setAuthentication => _authentication.sink.add;
   
+  AuthBloc(){
+    setAuthentication(AuthState.noneUser);
+  }
 
   @override
   dispose() {

--- a/pac_app/lib/bloc/AuthBloc.dart
+++ b/pac_app/lib/bloc/AuthBloc.dart
@@ -5,6 +5,15 @@ import 'package:pac_app/AuthState.dart';
 
 import 'package:rxdart/rxdart.dart';
 
+
+/**
+ * 권한 체크 Login AuthBloc
+ * 
+ * @author 서윤경
+ * @version 1.0
+ * @date 2019.08.16
+ */
+
 class AuthBloc implements Bloc {
   final _authentication = BehaviorSubject<AuthState>();
 

--- a/pac_app/lib/bloc/BlocProvider.dart
+++ b/pac_app/lib/bloc/BlocProvider.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:pac_app/bloc/LoginValidatorBloc.dart';
+
+class BlocProvider extends InheritedWidget {
+  final blocState = new _BlocState(
+    loginValidatorBloc: LoginValidatorBloc(),
+  );
+
+  BlocProvider({Key key, Widget child}) : super(key: key, child: child);
+
+  bool updateShouldNotify(_) => true;
+
+  static _BlocState of(BuildContext context) {
+    return (context.inheritFromWidgetOfExactType(BlocProvider) as BlocProvider)
+        .blocState;
+  }
+}
+
+class _BlocState {
+  final LoginValidatorBloc loginValidatorBloc;
+
+  _BlocState({
+    this.loginValidatorBloc
+  });
+}

--- a/pac_app/lib/bloc/BlocProvider.dart
+++ b/pac_app/lib/bloc/BlocProvider.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:pac_app/bloc/LoginValidatorBloc.dart';
+import 'AuthBloc.dart';
 
 class BlocProvider extends InheritedWidget {
   final blocState = new _BlocState(
     loginValidatorBloc: LoginValidatorBloc(),
+    authBloc:AuthBloc(),
   );
 
   BlocProvider({Key key, Widget child}) : super(key: key, child: child);
@@ -18,8 +20,11 @@ class BlocProvider extends InheritedWidget {
 
 class _BlocState {
   final LoginValidatorBloc loginValidatorBloc;
+  final AuthBloc authBloc;
 
   _BlocState({
-    this.loginValidatorBloc
+    this.loginValidatorBloc,
+    this.authBloc
   });
+
 }

--- a/pac_app/lib/bloc/BlocProvider.dart
+++ b/pac_app/lib/bloc/BlocProvider.dart
@@ -2,6 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:pac_app/bloc/LoginValidatorBloc.dart';
 import 'AuthBloc.dart';
 
+
+/**
+ * Multi Bloc 사용가능하게 해주는 BlocProvider
+ * 
+ * @author 서윤경
+ * @version 1.0
+ * @date 2019.08.16
+ */
+
 class BlocProvider extends InheritedWidget {
   final blocState = new _BlocState(
     loginValidatorBloc: LoginValidatorBloc(),

--- a/pac_app/lib/bloc/LoginValidatorBloc.dart
+++ b/pac_app/lib/bloc/LoginValidatorBloc.dart
@@ -19,6 +19,7 @@ class LoginValidatorBloc implements Bloc {
       Observable.combineLatest2(userId, password, (i, p) => true);
 
   Stream<UserModel> get currentUser => _currentUser.stream;
+  UserModel get getCurrentUserData => _currentUser.value;
 
   Function(String) get setUserId => _userId.sink.add;
   Function(String) get setPassword => _password.sink.add;

--- a/pac_app/lib/bloc/LoginValidatorBloc.dart
+++ b/pac_app/lib/bloc/LoginValidatorBloc.dart
@@ -22,7 +22,7 @@ class LoginValidatorBloc implements Bloc {
 
   Function(String) get setUserId => _userId.sink.add;
   Function(String) get setPassword => _password.sink.add;
-  Function(UserModel) get setCurrentUser =>_currentUser.sink.add;
+  Function(UserModel) get setCurrentUser => _currentUser.sink.add;
 
   final validatePassword = StreamTransformer<String, String>.fromHandlers(
       handleData: (password, sink) {
@@ -33,32 +33,35 @@ class LoginValidatorBloc implements Bloc {
     }
   });
 
-  Future<bool> fetchPost(String validUserId, String validPassword) async {
+  Future<UserModel> fetchPost(String validUserId, String validPassword) async {
     final userId = validUserId;
     final password = validPassword;
-
-    final response = await http.post('https://localhost:8080/users/login',
-        body: {'userId': userId, 'password': password});
+    //TODO: 서버주소로 옮기기
+    final response = await http.post('http://192.168.0.57:8080/users/login',
+        body: {"userId": userId, "password": password});
 
     if (response.statusCode == 200) {
-      this.setCurrentUser(UserModel.fromJson(json.decode(response.body)));
-      debugPrint(currentUser.toString());
-      return true;
+      debugPrint(response.body.toString()) ;
+      UserModel user = UserModel.fromJson(json.decode(response.body));
+      this.setCurrentUser(user);
+      
+      return user;
     } else {
       //error처리
-      return false;
-    
-  }}
+      return null;
+    }
+  }
 
-  submit() async {
+  Future<String> submit() async {
     final validUserId = _userId.value;
     final validPassword = _password.value;
     //백엔드 연결
     debugPrint(validUserId);
     debugPrint(validPassword);
-    if(await fetchPost(validUserId,validPassword)){
-
-    }else{
+    if (await fetchPost(validUserId, validPassword)!=null) {
+      return "true";
+    } else {
+      return "false";
       //ToDo: error처리
     }
   }

--- a/pac_app/lib/bloc/LoginValidatorBloc.dart
+++ b/pac_app/lib/bloc/LoginValidatorBloc.dart
@@ -7,6 +7,14 @@ import 'package:rxdart/rxdart.dart';
 
 import 'package:http/http.dart' as http;
 
+/**
+ * P&C의 Login 로직
+ *
+ * @author 서윤경
+ * @version 1.0, Login Bloc
+ * @date 2019.07.02
+ */
+
 class LoginValidatorBloc implements Bloc {
   final _userId = BehaviorSubject<String>();
   final _password = BehaviorSubject<String>();

--- a/pac_app/lib/bloc/LoginValidatorBloc.dart
+++ b/pac_app/lib/bloc/LoginValidatorBloc.dart
@@ -1,0 +1,72 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:bloc_provider/bloc_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:pac_app/model/UserModel.dart';
+import 'package:rxdart/rxdart.dart';
+
+import 'package:http/http.dart' as http;
+
+class LoginValidatorBloc implements Bloc {
+  final _userId = BehaviorSubject<String>();
+  final _password = BehaviorSubject<String>();
+
+  final _currentUser = BehaviorSubject<UserModel>();
+
+  Stream<String> get userId => _userId.stream;
+  Stream<String> get password => _password.stream.transform(validatePassword);
+  Stream<bool> get submitValid =>
+      Observable.combineLatest2(userId, password, (i, p) => true);
+
+  Stream<UserModel> get currentUser => _currentUser.stream;
+
+  Function(String) get setUserId => _userId.sink.add;
+  Function(String) get setPassword => _password.sink.add;
+  Function(UserModel) get setCurrentUser =>_currentUser.sink.add;
+
+  final validatePassword = StreamTransformer<String, String>.fromHandlers(
+      handleData: (password, sink) {
+    if (password.length > 8) {
+      sink.add(password);
+    } else {
+      sink.addError("Password Length must be over 8");
+    }
+  });
+
+  Future<bool> fetchPost(String validUserId, String validPassword) async {
+    final userId = validUserId;
+    final password = validPassword;
+
+    final response = await http.post('https://localhost:8080/users/login',
+        body: {'userId': userId, 'password': password});
+
+    if (response.statusCode == 200) {
+      this.setCurrentUser(UserModel.fromJson(json.decode(response.body)));
+      debugPrint(currentUser.toString());
+      return true;
+    } else {
+      //error처리
+      return false;
+    
+  }}
+
+  submit() async {
+    final validUserId = _userId.value;
+    final validPassword = _password.value;
+    //백엔드 연결
+    debugPrint(validUserId);
+    debugPrint(validPassword);
+    if(await fetchPost(validUserId,validPassword)){
+
+    }else{
+      //ToDo: error처리
+    }
+  }
+
+  @override
+  dispose() {
+    _userId.close();
+    _password.close();
+    _currentUser.close();
+  }
+}

--- a/pac_app/lib/fixed/appBar.dart
+++ b/pac_app/lib/fixed/appBar.dart
@@ -1,29 +1,95 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:pac_app/AuthState.dart';
+import 'package:pac_app/bloc/AuthBloc.dart';
 import 'package:pac_app/bloc/BlocProvider.dart';
+import 'package:pac_app/fixed/profile/User.dart';
+import 'package:pac_app/model/UserModel.dart';
 import 'package:pac_app/pages/LoginPage.dart';
 
 // ignore: camel_case_types
 class appBar {
-  static checkStatus(BuildContext context) {
-    if (context.widget.toString() != "MyHomePage") {
-      return new IconButton(
-        icon: new Icon(Icons.arrow_back, color: Colors.black),
-        onPressed: () {
-          Navigator.pop(context);
-        },
-      );
-    }
+  // static checkStatus(BuildContext context) {
+  //   if (context.widget.toString() != "MyHomePage") {
+  //     return new IconButton(
+  //       icon: new Icon(Icons.arrow_back, color: Colors.black),
+  //       onPressed: () {
+  //         Navigator.pop(context);
+  //       },
+  //     );
+  //   }
+  // }
+
+  static AppBar getAppBar(BuildContext context, AuthBloc bloc) {
+    AuthState authState;
+    bloc.authentication.listen((value) {
+      switch (value) {
+        case AuthState.admin:
+          return getAppBarWithAuthAdmin(context, bloc);
+          break;
+        case AuthState.user:
+          UserModel user = BlocProvider.of(context)
+              .loginValidatorBloc
+              .currentUser as UserModel;
+          return getAppBarWithAuthUser(context, bloc, user);
+
+          break;
+        case AuthState.noneUser:
+          return getAppBarWithNoneUser(context);
+          break;
+      }
+     
+    },  onError: (error) {
+      print("Some Error");
+    });
+    
   }
 
-  static getAppBar(BuildContext context) {
-    // TODO: status 에 따라서 login 전/후 만들기
-  
-    return 
-      AppBar(
-      leading: checkStatus(context),
+  static AppBar getAppBarWithAuthAdmin(BuildContext context, AuthBloc bloc) {
+    return AppBar(
       backgroundColor: Colors.white,
       actions: <Widget>[
+        //login button
+        Text(
+          "Admin",
+          style: TextStyle(fontSize: 15.0),
+        ),
+      ],
+    );
+  }
 
+  static AppBar getAppBarWithAuthUser(
+      BuildContext context, AuthBloc bloc, UserModel user) {
+    User currentUser = User(user: user);
+
+    return AppBar(
+      backgroundColor: Colors.white,
+      actions: <Widget>[
+        //login button
+        currentUser.getProfileImage(50),
+        Text(currentUser.user.nickName),
+        FlatButton(
+          textColor: Colors.black,
+          disabledColor: Colors.grey,
+          disabledTextColor: Colors.black,
+          splashColor: Colors.blueAccent,
+          onPressed: () {
+            bloc.setAuthentication(AuthState.noneUser);
+          },
+          child: Text(
+            "Logout",
+            style: TextStyle(fontSize: 15.0),
+          ),
+        ),
+      ],
+    );
+  }
+
+  static AppBar getAppBarWithNoneUser(BuildContext context) {
+    return AppBar(
+      backgroundColor: Colors.white,
+      actions: <Widget>[
         //login button
         FlatButton(
           textColor: Colors.black,
@@ -44,8 +110,4 @@ class appBar {
       ],
     );
   }
-
-  static AppBar getAppBarWithAuthAdmin(BuildContext context) {}
-
-  static AppBar getAppBarWithAuthUser(BuildContext context) {}
 }

--- a/pac_app/lib/fixed/appBar.dart
+++ b/pac_app/lib/fixed/appBar.dart
@@ -7,6 +7,7 @@ import 'package:pac_app/bloc/BlocProvider.dart';
 import 'package:pac_app/fixed/profile/User.dart';
 import 'package:pac_app/model/UserModel.dart';
 import 'package:pac_app/pages/LoginPage.dart';
+import '../style/textStyle.dart';
 
 // ignore: camel_case_types
 class appBar {
@@ -39,11 +40,9 @@ class appBar {
           return getAppBarWithNoneUser(context);
           break;
       }
-     
-    },  onError: (error) {
+    }, onError: (error) {
       print("Some Error");
     });
-    
   }
 
   static AppBar getAppBarWithAuthAdmin(BuildContext context, AuthBloc bloc) {
@@ -61,14 +60,21 @@ class appBar {
 
   static AppBar getAppBarWithAuthUser(
       BuildContext context, AuthBloc bloc, UserModel user) {
+    final theme = Theme.of(context);
     User currentUser = User(user: user);
-
     return AppBar(
       backgroundColor: Colors.white,
       actions: <Widget>[
         //login button
-        currentUser.getProfileImage(50),
-        Text(currentUser.user.nickName),
+        Column(children: <Widget>[
+          currentUser.getProfileImage(20),
+          Center(
+              child: Text(
+            "" + currentUser.user.nickName,
+            style: textStyle.contextText,
+            textAlign: TextAlign.center,
+          )),
+        ]),
         FlatButton(
           textColor: Colors.black,
           disabledColor: Colors.grey,

--- a/pac_app/lib/fixed/appBar.dart
+++ b/pac_app/lib/fixed/appBar.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:pac_app/AuthState.dart';
 import 'package:pac_app/bloc/AuthBloc.dart';
@@ -8,7 +6,13 @@ import 'package:pac_app/fixed/profile/User.dart';
 import 'package:pac_app/model/UserModel.dart';
 import 'package:pac_app/pages/LoginPage.dart';
 import '../style/textStyle.dart';
-
+/**
+ * P&C의 구성하는 appBar
+ *
+ * @author 서윤경
+ * @version 1.0, P&C 의 appBar
+ * @date 2019.08.16
+ */
 // ignore: camel_case_types
 class appBar {
   // static checkStatus(BuildContext context) {

--- a/pac_app/lib/fixed/appBar.dart
+++ b/pac_app/lib/fixed/appBar.dart
@@ -1,23 +1,29 @@
 import 'package:flutter/material.dart';
+import 'package:pac_app/bloc/BlocProvider.dart';
 import 'package:pac_app/pages/LoginPage.dart';
 
 // ignore: camel_case_types
 class appBar {
-  
-  static checkStatus(BuildContext context){
-    if(context.widget.toString() != "MyHomePage"){
+  static checkStatus(BuildContext context) {
+    if (context.widget.toString() != "MyHomePage") {
       return new IconButton(
-          icon: new Icon(Icons.arrow_back, color: Colors.black),
-          onPressed: (){Navigator.pop(context);},);
+        icon: new Icon(Icons.arrow_back, color: Colors.black),
+        onPressed: () {
+          Navigator.pop(context);
+        },
+      );
     }
   }
-  
-  static getAppBar(BuildContext context, bool status) {
+
+  static getAppBar(BuildContext context) {
     // TODO: status 에 따라서 login 전/후 만들기
-    return new AppBar(
+  
+    return 
+      AppBar(
       leading: checkStatus(context),
       backgroundColor: Colors.white,
       actions: <Widget>[
+
         //login button
         FlatButton(
           textColor: Colors.black,
@@ -38,4 +44,8 @@ class appBar {
       ],
     );
   }
+
+  static AppBar getAppBarWithAuthAdmin(BuildContext context) {}
+
+  static AppBar getAppBarWithAuthUser(BuildContext context) {}
 }

--- a/pac_app/lib/fixed/appBar.dart
+++ b/pac_app/lib/fixed/appBar.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:pac_app/pages/loginPage.dart';
+import 'package:pac_app/pages/LoginPage.dart';
 
 // ignore: camel_case_types
 class appBar {
@@ -27,7 +27,7 @@ class appBar {
           onPressed: () {
             Navigator.push(
               context,
-              MaterialPageRoute(builder: (context) => loginPage()),
+              MaterialPageRoute(builder: (context) => LoginPage()),
             );
           },
           child: Text(

--- a/pac_app/lib/fixed/profile/User.dart
+++ b/pac_app/lib/fixed/profile/User.dart
@@ -1,6 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:pac_app/model/UserModel.dart';
 
+
+/**
+ * 사용자 모델 활용한 Logic
+ * 
+ * @author 서윤경
+ * @version 1.0
+ * @date 2019.08.16
+ */
+
 class User {
   UserModel user;
   User({this.user});

--- a/pac_app/lib/fixed/profile/User.dart
+++ b/pac_app/lib/fixed/profile/User.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:pac_app/model/UserModel.dart';
+
+class User {
+  UserModel user;
+  User({this.user});
+
+  Widget getProfileImage(double radius) {
+    print(user.profileImgPath);
+    return CircleAvatar(
+      //backgroundColor: Colors.brown.shade800,
+      radius: radius,
+      backgroundImage: NetworkImage(user.profileImgPath),
+    );
+  }
+}

--- a/pac_app/lib/main.dart
+++ b/pac_app/lib/main.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:pac_app/fixed/appBar.dart' as prefix0;
+import 'package:pac_app/model/UserModel.dart';
 import 'package:pac_app/pages/homePage.dart';
 import 'package:pac_app/pages/recipeShowPage.dart';
 
@@ -67,23 +69,23 @@ class _MyHomePageState extends State<MyHomePage> {
     ];
 
     final bloc = BlocProvider.of(context).authBloc;
-
-    AppBar appbar;
-    bloc.authentication.listen((auth) {
-      switch (auth) {
-        case AuthState.admin:
-          appbar = appBar.getAppBarWithAuthAdmin(context);
-          break;
-        case AuthState.user:
-          appbar = appBar.getAppBarWithAuthUser(context);
-          break;
-        case AuthState.noneUser:
-          appbar = appBar.getAppBar(context);
-      }
-    });
     return BlocProvider(
         child: Scaffold(
-            appBar: appBar.getAppBar(context),
+            appBar: PreferredSize(
+    preferredSize: const Size(double.infinity, kToolbarHeight),
+    child: StreamBuilder(
+      stream: bloc.authentication,
+      builder: (context,snapshot){
+        if(snapshot.data==AuthState.admin){
+          return appBar.getAppBarWithAuthAdmin(context, bloc);
+        }else if(snapshot.data==AuthState.user){
+          return appBar.getAppBarWithAuthUser(context, bloc,BlocProvider.of(context).loginValidatorBloc.currentUser as UserModel);
+        }else {
+          return appBar.getAppBarWithNoneUser(context);
+        }
+      },
+    )// StreamBuilder
+  ),
             body: Center(child: _widgetOptions[_selectedViewIndex]),
             bottomNavigationBar: BottomNavigationBar(
                 items: <BottomNavigationBarItem>[

--- a/pac_app/lib/main.dart
+++ b/pac_app/lib/main.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:pac_app/pages/homePage.dart';
-import 'package:pac_app/pages/loginPage.dart';
-import 'package:pac_app/pages/registerPage.dart';
-import 'package:pac_app/pages/selectIngredientPage.dart';
 
+import 'AuthState.dart';
 import 'fixed/appBar.dart';
 import 'package:pac_app/bloc/BlocProvider.dart';
 
@@ -13,7 +11,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-          child: MaterialApp(
+      child: MaterialApp(
           title: 'Flutter Demo',
           theme: ThemeData(
             primarySwatch: Colors.blue,
@@ -66,21 +64,36 @@ class _MyHomePageState extends State<MyHomePage> {
       //or you can add more widget
     ];
 
-    return Scaffold(
-        appBar: appBar.getAppBar(context, false),
+    final bloc = BlocProvider.of(context).authBloc;
 
-        body: Center(child: _widgetOptions[_selectedViewIndex]),
-        bottomNavigationBar: BottomNavigationBar(
-            items: <BottomNavigationBarItem>[
-              BottomNavigationBarItem(
-                  icon: Icon(Icons.people), title: Text('Community')),
-              BottomNavigationBarItem(
-                  icon: Icon(Icons.home), title: Text('Home')),
-              BottomNavigationBarItem(
-                  icon: Icon(Icons.assignment), title: Text('My Recipe')),
-            ],
-            currentIndex: _selectedNavigatorIndex,
-            selectedItemColor: Colors.amber[800],
-            onTap: _changeView));
+    AppBar appbar;
+    bloc.authentication.listen((auth) {
+      switch (auth) {
+        case AuthState.admin:
+          appbar = appBar.getAppBarWithAuthAdmin(context);
+          break;
+        case AuthState.user:
+          appbar = appBar.getAppBarWithAuthUser(context);
+          break;
+        case AuthState.noneUser:
+          appbar = appBar.getAppBarWithNoneUser(context);
+      }
+    });
+    return BlocProvider(
+        child: Scaffold(
+            appBar: appBar.getAppBar(context, false),
+            body: Center(child: _widgetOptions[_selectedViewIndex]),
+            bottomNavigationBar: BottomNavigationBar(
+                items: <BottomNavigationBarItem>[
+                  BottomNavigationBarItem(
+                      icon: Icon(Icons.people), title: Text('Community')),
+                  BottomNavigationBarItem(
+                      icon: Icon(Icons.home), title: Text('Home')),
+                  BottomNavigationBarItem(
+                      icon: Icon(Icons.assignment), title: Text('My Recipe')),
+                ],
+                currentIndex: _selectedNavigatorIndex,
+                selectedItemColor: Colors.amber[800],
+                onTap: _changeView)));
   }
 }

--- a/pac_app/lib/main.dart
+++ b/pac_app/lib/main.dart
@@ -28,7 +28,7 @@ class MyHomePage extends StatefulWidget {
   MyHomePage({Key key, this.title}) : super(key: key);
   final String title;
 
-  @override
+  @override 
   _MyHomePageState createState() => _MyHomePageState();
 }
 
@@ -68,18 +68,19 @@ class _MyHomePageState extends State<MyHomePage> {
       //or you can add more widget
     ];
 
-    final bloc = BlocProvider.of(context).authBloc;
+    final authBloc = BlocProvider.of(context).authBloc;
+    final loginBloc = BlocProvider.of(context).loginValidatorBloc;
     return BlocProvider(
         child: Scaffold(
             appBar: PreferredSize(
     preferredSize: const Size(double.infinity, kToolbarHeight),
     child: StreamBuilder(
-      stream: bloc.authentication,
+      stream: authBloc.authentication,
       builder: (context,snapshot){
         if(snapshot.data==AuthState.admin){
-          return appBar.getAppBarWithAuthAdmin(context, bloc);
+          return appBar.getAppBarWithAuthAdmin(context, authBloc);
         }else if(snapshot.data==AuthState.user){
-          return appBar.getAppBarWithAuthUser(context, bloc,BlocProvider.of(context).loginValidatorBloc.currentUser as UserModel);
+          return appBar.getAppBarWithAuthUser(context, authBloc,loginBloc.getCurrentUserData);
         }else {
           return appBar.getAppBarWithNoneUser(context);
         }

--- a/pac_app/lib/main.dart
+++ b/pac_app/lib/main.dart
@@ -5,19 +5,21 @@ import 'package:pac_app/pages/registerPage.dart';
 import 'package:pac_app/pages/selectIngredientPage.dart';
 
 import 'fixed/appBar.dart';
+import 'package:pac_app/bloc/BlocProvider.dart';
 
 void main() => runApp(MyApp());
 
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-
-        title: 'Flutter Demo',
-        theme: ThemeData(
-          primarySwatch: Colors.blue,
-        ),
-        home: MyHomePage());
+    return BlocProvider(
+          child: MaterialApp(
+          title: 'Flutter Demo',
+          theme: ThemeData(
+            primarySwatch: Colors.blue,
+          ),
+          home: MyHomePage()),
+    );
   }
 }
 

--- a/pac_app/lib/main.dart
+++ b/pac_app/lib/main.dart
@@ -1,12 +1,18 @@
 import 'package:flutter/material.dart';
-import 'package:pac_app/fixed/appBar.dart' as prefix0;
-import 'package:pac_app/model/UserModel.dart';
 import 'package:pac_app/pages/homePage.dart';
 import 'package:pac_app/pages/recipeShowPage.dart';
 
 import 'AuthState.dart';
 import 'fixed/appBar.dart';
 import 'package:pac_app/bloc/BlocProvider.dart';
+
+/**
+ * P&C의 메인 총 구성
+ *
+ * @author 서윤경
+ * @version 1.0, P&C 의 총 구성 main
+ * @date 2019.08.16
+ */
 
 void main() => runApp(MyApp());
 

--- a/pac_app/lib/model/UserModel.dart
+++ b/pac_app/lib/model/UserModel.dart
@@ -1,0 +1,16 @@
+class UserModel {
+  String id;
+  String nickName;
+  String password;
+  String profileImgPath;
+
+  UserModel({this.id, this.nickName, this.password, this.profileImgPath});
+
+  Future getImageUrl() async {
+    // Null check so our app isn't doing extra work.
+    // If there's already an image, we don't need to get one.
+    if (profileImgPath != null) {
+      return;
+    }
+  }
+}

--- a/pac_app/lib/model/UserModel.dart
+++ b/pac_app/lib/model/UserModel.dart
@@ -13,4 +13,12 @@ class UserModel {
       return;
     }
   }
+
+  factory UserModel.fromJson(Map<String,dynamic> json) {
+      return UserModel(
+        id: json['userId'],
+        nickName:json['nickName'],
+        profileImgPath: json['imgPath']
+      );
+  }
 }

--- a/pac_app/lib/model/UserModel.dart
+++ b/pac_app/lib/model/UserModel.dart
@@ -1,3 +1,12 @@
+
+/**
+ * 사용자 Data Model
+ * 
+ * @author 서윤경
+ * @version 1.0
+ * @date 2019.08.16
+ */
+
 class UserModel {
   String id;
   String nickName;

--- a/pac_app/lib/pages/homePage.dart
+++ b/pac_app/lib/pages/homePage.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:carousel_slider/carousel_slider.dart';
 import 'package:pac_app/fixed/recipe/bestRecipe/bestRecipe.dart';
 
 /**
@@ -10,9 +9,6 @@ import 'package:pac_app/fixed/recipe/bestRecipe/bestRecipe.dart';
  * @date 2019.07.02
  */
 
-import 'package:flutter/material.dart';
-
-import 'package:carousel_slider/carousel_slider.dart';
 import '../pages/selectIngredientPage.dart';
 import '../style/textStyle.dart';
 

--- a/pac_app/lib/pages/loginPage.dart
+++ b/pac_app/lib/pages/loginPage.dart
@@ -4,8 +4,10 @@ import 'package:flutter_signin_button/button_builder.dart';
 import 'package:flutter_signin_button/button_list.dart';
 import 'package:flutter_signin_button/button_view.dart';
 import 'package:pac_app/AuthState.dart';
+import 'package:pac_app/bloc/AuthBloc.dart';
 import 'package:pac_app/bloc/BlocProvider.dart';
 import 'package:pac_app/bloc/LoginValidatorBloc.dart';
+import 'package:pac_app/main.dart';
 
 import '../style/textStyle.dart';
 import 'registerPage.dart';
@@ -15,7 +17,8 @@ import '../bloc/BlocProvider.dart';
 class LoginPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final bloc = BlocProvider.of(context).loginValidatorBloc;
+    final loginBloc = BlocProvider.of(context).loginValidatorBloc;
+    final authBloc = BlocProvider.of(context).authBloc;
 
     return BlocProvider(
       child: Scaffold(
@@ -34,9 +37,9 @@ class LoginPage extends StatelessWidget {
                       Text('for Pick & Cook', style: textStyle.subHeadLineText),
                     ],
                   )),
-              userIdField(bloc),
-              passwordField(bloc),
-              submitButtonField(bloc),
+              userIdField(loginBloc),
+              passwordField(loginBloc),
+              submitButtonField(loginBloc,authBloc),
               signInButtonField(context)
             ],
           ),
@@ -80,6 +83,7 @@ class LoginPage extends StatelessWidget {
             child: TextField(
               onChanged: bloc.setPassword,
               style: new TextStyle(height: 0.5, color: Colors.black),
+              obscureText: true,
               decoration: InputDecoration(
                   border: OutlineInputBorder(
                       borderRadius: BorderRadius.all(Radius.circular(10.0)),
@@ -93,7 +97,7 @@ class LoginPage extends StatelessWidget {
         });
   }
 
-  submitButtonField(LoginValidatorBloc bloc) {
+  submitButtonField(LoginValidatorBloc bloc, AuthBloc authBloc) {
     return StreamBuilder(
         stream: bloc.submitValid,
         builder: (context, snapshot) {
@@ -111,10 +115,9 @@ class LoginPage extends StatelessWidget {
                   bloc
                       .submit()
                       .then((onValue) => {
-                            BlocProvider.of(context)
-                                .authBloc
+                            authBloc
                                 .setAuthentication(AuthState.user),
-                            Navigator.pop(context)
+                            Navigator.push(context, MaterialPageRoute(builder: (context) => MyHomePage()))
                           })
                       .catchError((onError) => {
                             showDialog(

--- a/pac_app/lib/pages/loginPage.dart
+++ b/pac_app/lib/pages/loginPage.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_signin_button/button_builder.dart';
 import 'package:flutter_signin_button/button_list.dart';
 import 'package:flutter_signin_button/button_view.dart';
+import 'package:pac_app/AuthState.dart';
 import 'package:pac_app/bloc/BlocProvider.dart';
 import 'package:pac_app/bloc/LoginValidatorBloc.dart';
 
@@ -109,7 +110,12 @@ class LoginPage extends StatelessWidget {
                 onPressed: () {
                   bloc
                       .submit()
-                      .then((onValue) => {Navigator.pop(context)})
+                      .then((onValue) => {
+                            BlocProvider.of(context)
+                                .authBloc
+                                .setAuthentication(AuthState.user),
+                            Navigator.pop(context)
+                          })
                       .catchError((onError) => {
                             showDialog(
                                 context: context,

--- a/pac_app/lib/pages/loginPage.dart
+++ b/pac_app/lib/pages/loginPage.dart
@@ -14,6 +14,15 @@ import 'registerPage.dart';
 
 import '../bloc/BlocProvider.dart';
 
+
+/**
+ * Login Page 
+ * 
+ * @author 서윤경
+ * @version 1.0
+ * @date 2019.08.16
+ */
+
 class LoginPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {

--- a/pac_app/lib/pages/loginPage.dart
+++ b/pac_app/lib/pages/loginPage.dart
@@ -3,100 +3,140 @@ import 'package:flutter/material.dart';
 import 'package:flutter_signin_button/button_builder.dart';
 import 'package:flutter_signin_button/button_list.dart';
 import 'package:flutter_signin_button/button_view.dart';
+import 'package:pac_app/bloc/BlocProvider.dart';
+import 'package:pac_app/bloc/LoginValidatorBloc.dart';
 
 import '../style/textStyle.dart';
 import 'registerPage.dart';
 
-class loginPage extends StatelessWidget {
+import '../bloc/BlocProvider.dart';
+
+class LoginPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      resizeToAvoidBottomPadding: false,
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: Column(
-                  children: <Widget>[
-                    Text('Login ',
-                        style: textStyle.headLineText),
-                    Text('for Pick & Cook',
-                        style: textStyle.subHeadLineText),
-                  ],
-                )),
-            Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 40),
-                child: Column(children: <Widget>[
-                  Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: TextField(
-                      style: new TextStyle(height: 0.5, color: Colors.black),
-                      decoration: InputDecoration(
-                          border: OutlineInputBorder(
-                              borderRadius:
-                                  BorderRadius.all(Radius.circular(10.0)),
-                              borderSide: BorderSide(
-                                color: Colors.black,
-                                width: 0.8,
-                              )),
-                          hintText: 'ID'),
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: TextField(
-                      style: new TextStyle(height: 0.5, color: Colors.black),
-                      decoration: InputDecoration(
-                          border: OutlineInputBorder(
-                              borderRadius:
-                                  BorderRadius.all(Radius.circular(10.0)),
-                              borderSide: BorderSide(
-                                color: Colors.black,
-                                width: 0.8,
-                              )),
-                          hintText: 'Password'),
-                    ),
-                  ),
-                  SizedBox(
-                    width: 225, //TODO: 비율로바꿔야할듯...
-                    child: RaisedButton(
-                        //TODO: 버튼에 애니메이션 입히기
-                        padding: const EdgeInsets.all(8.0),
-                        textColor: Colors.black,
-                        color: Colors.white,
-                        shape: new RoundedRectangleBorder(
-                            borderRadius:
-                                BorderRadius.all(Radius.circular(10.0)),
-                            side: BorderSide(color: Colors.black, width: 0.8)),
-                        onPressed: () {
-                          Navigator.pop(
-                              context); // TODO: 로그인 validation 및 status
-                        },
-                        child: new Text('Login')),
-                  )
-                ])),
-            SignInButtonBuilder(
-              text: 'Sign in with Pick & Cook',
-              icon: Icons.add_box,
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => registerPage()),
-                );
-              },
-              backgroundColor: Colors.blueGrey[700],
-            ),
-            SignInButton(
-              Buttons.Facebook,
-              onPressed: () {},
-            ),
-          ],
+    final bloc = BlocProvider.of(context).loginValidatorBloc;
+
+    return BlocProvider(
+      child: Scaffold(
+        resizeToAvoidBottomPadding: false,
+        body: Center(
+          // Center is a layout widget. It takes a single child and positions it
+          // in the middle of the parent.
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Column(
+                    children: <Widget>[
+                      Text('Login ', style: textStyle.headLineText),
+                      Text('for Pick & Cook', style: textStyle.subHeadLineText),
+                    ],
+                  )),
+              userIdField(bloc),
+              passwordField(bloc),
+              submitButtonField(bloc),
+              signInButtonField(context)
+            ],
+          ),
         ),
       ),
+    );
+  }
+
+  Widget userIdField(LoginValidatorBloc bloc) {
+    return StreamBuilder(
+        stream: bloc.userId,
+        builder: (context, snapshop) {
+          // return Padding(
+          //     padding: const EdgeInsets.symmetric(horizontal: 40),
+          //     child: Column(children: <Widget>[
+          return Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: TextField(
+              onChanged: bloc.setUserId,
+              style: new TextStyle(height: 0.5, color: Colors.black),
+              decoration: InputDecoration(
+                  border: OutlineInputBorder(
+                      borderRadius: BorderRadius.all(Radius.circular(10.0)),
+                      borderSide: BorderSide(
+                        color: Colors.black,
+                        width: 0.8,
+                      )),
+                  hintText: 'ID'),
+            ),
+          );
+          // ]));
+        });
+  }
+
+  passwordField(LoginValidatorBloc bloc) {
+    return StreamBuilder(
+        stream: bloc.password,
+        builder: (context, snapshot) {
+          return Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: TextField(
+              onChanged: bloc.setPassword,
+              style: new TextStyle(height: 0.5, color: Colors.black),
+              decoration: InputDecoration(
+                  border: OutlineInputBorder(
+                      borderRadius: BorderRadius.all(Radius.circular(10.0)),
+                      borderSide: BorderSide(
+                        color: Colors.black,
+                        width: 0.8,
+                      )),
+                  hintText: 'Password'),
+            ),
+          );
+        });
+  }
+
+  submitButtonField(LoginValidatorBloc bloc) {
+    return StreamBuilder(
+        stream: bloc.submitValid,
+        builder: (context, snapshot) {
+          return SizedBox(
+            width: 225, //TODO: 비율로바꿔야할듯...
+            child: RaisedButton(
+                //TODO: 버튼에 애니메이션 입히기
+                padding: const EdgeInsets.all(8.0),
+                textColor: Colors.black,
+                color: Colors.white,
+                shape: new RoundedRectangleBorder(
+                    borderRadius: BorderRadius.all(Radius.circular(10.0)),
+                    side: BorderSide(color: Colors.black, width: 0.8)),
+                onPressed: () {
+                  if (snapshot.hasData) {
+                    if (bloc.submit()) {
+                      Navigator.pop(context);
+                    }
+                  }
+                },
+                child: new Text('Login')),
+          );
+        });
+  }
+
+  signInButtonField(BuildContext context) {
+    return Column(
+      children: <Widget>[
+        SignInButtonBuilder(
+          text: 'Sign in with Pick & Cook',
+          icon: Icons.add_box,
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => registerPage()),
+            );
+          },
+          backgroundColor: Colors.blueGrey[700],
+        ),
+        SignInButton(
+          Buttons.Facebook,
+          onPressed: () {},
+        )
+      ],
     );
   }
 }

--- a/pac_app/lib/pages/loginPage.dart
+++ b/pac_app/lib/pages/loginPage.dart
@@ -107,11 +107,29 @@ class LoginPage extends StatelessWidget {
                     borderRadius: BorderRadius.all(Radius.circular(10.0)),
                     side: BorderSide(color: Colors.black, width: 0.8)),
                 onPressed: () {
-                  if (snapshot.hasData) {
-                    if (bloc.submit()) {
-                      Navigator.pop(context);
-                    }
-                  }
+                  bloc
+                      .submit()
+                      .then((onValue) => {Navigator.pop(context)})
+                      .catchError((onError) => {
+                            showDialog(
+                                context: context,
+                                barrierDismissible:
+                                    false, // user must tap button!
+                                builder: (BuildContext context) {
+                                  return AlertDialog(
+                                    title: Text("Error occurs"),
+                                    content: Text(onError),
+                                    actions: <Widget>[
+                                      FlatButton(
+                                        child: Text('Regret'),
+                                        onPressed: () {
+                                          Navigator.of(context).pop();
+                                        },
+                                      ),
+                                    ],
+                                  );
+                                })
+                          });
                 },
                 child: new Text('Login')),
           );

--- a/pac_app/lib/pages/searchResultPage.dart
+++ b/pac_app/lib/pages/searchResultPage.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:pac_app/bloc/BlocProvider.dart';
 //import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:pac_app/fixed/appBar.dart';
@@ -31,6 +32,7 @@ class _searchResultPageState extends State<searchResultPage> {
   @override
   Widget build(BuildContext context) {
     //final AddListItemBloc _addItemBloc = BlocProvider.of(context);
+    final bloc = BlocProvider.of(context).authBloc;
     List<CustomListItem> searchResult = [
       CustomListItem(
           'https://i.imgur.com/Z1LR83S.png', 'big quoka', 'very lovable'),
@@ -39,7 +41,7 @@ class _searchResultPageState extends State<searchResultPage> {
     ];
 
     return Scaffold(
-      appBar: appBar.getAppBar(context),
+      appBar: appBar.getAppBar(context,bloc),
       body: Column(
           mainAxisAlignment: MainAxisAlignment.start,
           mainAxisSize: MainAxisSize.max,

--- a/pac_app/lib/pages/searchResultPage.dart
+++ b/pac_app/lib/pages/searchResultPage.dart
@@ -4,7 +4,6 @@ import 'package:pac_app/bloc/BlocProvider.dart';
 
 import 'package:pac_app/fixed/appBar.dart';
 import 'package:pac_app/fixed/CustomListItem.dart';
-import 'package:pac_app/fixed/appBar.dart' as prefix0;
 import 'package:pac_app/fixed/ingredientInfo/ingredientChip.dart';
 //import 'package:pac_app/pages/searchResultUpdateBloc.dart';
 

--- a/pac_app/lib/pages/selectIngredientPage.dart
+++ b/pac_app/lib/pages/selectIngredientPage.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:pac_app/bloc/BlocProvider.dart';
 import 'package:pac_app/fixed/appBar.dart' as prefix0;
 import '../fixed/appBar.dart';
 import '../fixed/ingredientInfo/ingredientsList.dart';
@@ -23,8 +24,9 @@ class _selectIngredientPageState extends State<selectIngredientPage> {
 
   @override
   Widget build(BuildContext context) {
+    final bloc = BlocProvider.of(context).authBloc;
     return new Scaffold(
-      appBar: appBar.getAppBar(context),
+      appBar: appBar.getAppBar(context,bloc),
       body: new Column(
           mainAxisAlignment: MainAxisAlignment.start,
           mainAxisSize: MainAxisSize.max,

--- a/pac_app/lib/pages/selectIngredientPage.dart
+++ b/pac_app/lib/pages/selectIngredientPage.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:pac_app/bloc/BlocProvider.dart';
-import 'package:pac_app/fixed/appBar.dart' as prefix0;
 import '../fixed/appBar.dart';
 import '../fixed/ingredientInfo/ingredientsList.dart';
 import '../fixed/ingredientInfo/ingredient.dart';

--- a/pac_app/lib/style/textStyle.dart
+++ b/pac_app/lib/style/textStyle.dart
@@ -13,4 +13,6 @@ abstract class textStyle {
       fontWeight: FontWeight.w800, fontSize: 30, fontStyle: FontStyle.italic);
   static const subHeadLineText = TextStyle(
       fontWeight: FontWeight.w800, fontSize: 20, fontStyle: FontStyle.italic);
+  static const contextText = TextStyle(
+      fontWeight: FontWeight.bold, fontSize: 10, fontStyle: FontStyle.normal, color: Colors.black);
 }

--- a/pac_app/pubspec.lock
+++ b/pac_app/pubspec.lock
@@ -15,6 +15,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.14.4"
+  bloc_provider:
+    dependency: "direct main"
+    description:
+      name: bloc_provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.2+1"
   boolean_selector:
     dependency: transitive
     description:
@@ -81,6 +88,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "8.5.0"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.12.0+2"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.3"
   matcher:
     dependency: transitive
     description:

--- a/pac_app/pubspec.yaml
+++ b/pac_app/pubspec.yaml
@@ -14,7 +14,7 @@ description: A new Flutter application.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.2.0 <3.0.0"
+  sdk: ">=2.2.2 <3.0.0"
 
 dependencies:
   flutter:
@@ -24,7 +24,9 @@ dependencies:
   flutter_signin_button: ^0.2.8
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
+  cupertino_icons: ^0.1.2 
+  bloc_provider: ^0.6.2+1
+  http: any
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 로그인 전 Main Page
<img width="181" alt="p c_main" src="https://user-images.githubusercontent.com/20858548/63139137-22f8f580-c018-11e9-98ae-23f9a2f6ac05.PNG">

## 로그인 시 로그인 페이지
<img width="178" alt="p c_login" src="https://user-images.githubusercontent.com/20858548/63139154-34da9880-c018-11e9-94bb-2dcc34c2f255.PNG">

## 로그인 후 Main Page
<img width="183" alt="p c_login_after" src="https://user-images.githubusercontent.com/20858548/63139163-3c9a3d00-c018-11e9-904a-37e32a53e905.PNG">


- 로그인 전, noneUser Auth 줌 
- 로그인 후, User의 정보와 User Auth 줌 
- LoginValidator에 있는 currentUser를 통해 현재 user의 data자유롭게 사용 가능
 (캐쉬화 시켜줄 필요있을 듯)

### TODO
- 사이즈 동적으로 처리하기 


백엔드 git참조 : https://github.com/pacpacs/pac_server 의 sev_userAPI 브랜치 참조 